### PR TITLE
Store Todo items in SQLite

### DIFF
--- a/TodoMvc/Controllers/TodoController.cs
+++ b/TodoMvc/Controllers/TodoController.cs
@@ -1,19 +1,23 @@
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using TodoMvc.Models;
+using TodoMvc.Data;
 
 namespace TodoMvc.Controllers
 {
     public class TodoController : Controller
     {
-        // In-memory store for simplicity
-        private static readonly List<TodoItem> Items = new();
-        private static int _nextId = 1;
+        private readonly TodoContext _context;
 
-        public IActionResult Index()
+        public TodoController(TodoContext context)
         {
-            return View(Items);
+            _context = context;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var items = await _context.Items.AsNoTracking().ToListAsync();
+            return View(items);
         }
 
         [HttpGet]
@@ -24,38 +28,40 @@ namespace TodoMvc.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public IActionResult Create(string title)
+        public async Task<IActionResult> Create(string title)
         {
             if (!string.IsNullOrWhiteSpace(title))
             {
-                Items.Add(new TodoItem
+                _context.Items.Add(new TodoItem
                 {
-                    Id = _nextId++,
                     Title = title,
                     IsCompleted = false
                 });
+                await _context.SaveChangesAsync();
             }
             return RedirectToAction(nameof(Index));
         }
 
         [HttpPost]
-        public IActionResult Toggle(int id)
+        public async Task<IActionResult> Toggle(int id)
         {
-            var item = Items.FirstOrDefault(t => t.Id == id);
+            var item = await _context.Items.FindAsync(id);
             if (item != null)
             {
                 item.IsCompleted = !item.IsCompleted;
+                await _context.SaveChangesAsync();
             }
             return RedirectToAction(nameof(Index));
         }
 
         [HttpPost]
-        public IActionResult Delete(int id)
+        public async Task<IActionResult> Delete(int id)
         {
-            var item = Items.FirstOrDefault(t => t.Id == id);
+            var item = await _context.Items.FindAsync(id);
             if (item != null)
             {
-                Items.Remove(item);
+                _context.Items.Remove(item);
+                await _context.SaveChangesAsync();
             }
             return RedirectToAction(nameof(Index));
         }

--- a/TodoMvc/Data/TodoContext.cs
+++ b/TodoMvc/Data/TodoContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using TodoMvc.Models;
+
+namespace TodoMvc.Data
+{
+    public class TodoContext : DbContext
+    {
+        public TodoContext(DbContextOptions<TodoContext> options)
+            : base(options)
+        {
+            Database.EnsureCreated();
+        }
+
+        public DbSet<TodoItem> Items => Set<TodoItem>();
+    }
+}

--- a/TodoMvc/Program.cs
+++ b/TodoMvc/Program.cs
@@ -2,13 +2,23 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+using TodoMvc.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+builder.Services.AddDbContext<TodoContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("Default") ?? "Data Source=todos.db"));
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<TodoContext>();
+    context.Database.EnsureCreated();
+}
 
 if (!app.Environment.IsDevelopment())
 {

--- a/TodoMvc/README.md
+++ b/TodoMvc/README.md
@@ -14,6 +14,6 @@ dotnet restore
 dotnet run
 ```
 
-The application will be available at `https://localhost:5001` by default. The index page displays a basic Todo List where you can add, toggle, and delete items. All data is stored in memory.
+The application will be available at `https://localhost:5001` by default. The index page displays a basic Todo List where you can add, toggle, and delete items. Data is persisted in a local **SQLite** database located in `todos.db`.
 
 The views use [Bootstrap 5](https://getbootstrap.com/) for a responsive layout styled similarly to the **Front Dashboard** theme.

--- a/TodoMvc/TodoMvc.csproj
+++ b/TodoMvc/TodoMvc.csproj
@@ -2,5 +2,9 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
+</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- switch from in-memory list to Entity Framework Core
- register SQLite `TodoContext`
- create asynchronous CRUD actions
- ensure database is created at startup
- update README

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dece0c284832687ff700ef42a8e5b